### PR TITLE
Add `all` as a Dependency for `qemu-*` Targets

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
       "label": "build",
       "detail": "Compile and Run FOS",
       "type": "shell",
-      "command": "make && make qemu",
+      "command": "make qemu",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -15,7 +15,7 @@
       "label": "build-debug",
       "detail": "Compile and Run FOS in debug mode",
       "type": "shell",
-      "command": "make && make qemu-gdb",
+      "command": "make qemu-gdb",
       "isBackground": true,
       "problemMatcher": {
         "pattern": [

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,10 +68,10 @@ GDBPORT 	= 26000
 QEMUGDB 	= -gdb tcp::$(GDBPORT)
 QEMUOPTS 	= -drive file=$(IMAGE),media=disk,format=raw -smp 2 -m 32 $(QEMUEXTRAS)
 
-qemu:
+qemu: all
 	$(V)$(QEMU) -serial mon:stdio $(QEMUOPTS)
 
-qemu-gdb:
+qemu-gdb: all
 	$(QEMU) $(QEMUOPTS) -S $(QEMUGDB)
 
 


### PR DESCRIPTION
Added the target 'all' as a dependency to the targets 'qemu' and 'qemu-gdb'.
This should now build before running the emulation.