### PR TITLE
Allow Scrolling in QEMU

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,7 +69,7 @@ QEMUGDB 	= -gdb tcp::$(GDBPORT)
 QEMUOPTS 	= -drive file=$(IMAGE),media=disk,format=raw -smp 2 -m 32 $(QEMUEXTRAS)
 
 qemu: all
-	$(V)$(QEMU) -serial mon:stdio $(QEMUOPTS)
+	$(V)$(QEMU) -parallel mon:stdio $(QEMUOPTS)
 
 qemu-gdb: all
 	$(QEMU) $(QEMUOPTS) -S $(QEMUGDB)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@
 V 			:= @
 TOP 		:= .
 OBJDIR 		:= obj
-TOOLPREFIX 	:= /opt/cross/bin/i386-elf-
+TOOLPREFIX 	:= i386-elf-
 QEMU 		:= qemu-system-i386
 PERL		:= perl
 IMAGE 		:= $(OBJDIR)/fos.img

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@
 V 			:= @
 TOP 		:= .
 OBJDIR 		:= obj
-TOOLPREFIX 	:= i386-elf-
+TOOLPREFIX 	:= /opt/cross/bin/i386-elf-
 QEMU 		:= qemu-system-i386
 PERL		:= perl
 IMAGE 		:= $(OBJDIR)/fos.img

--- a/README.md
+++ b/README.md
@@ -92,14 +92,8 @@ The [Windows Subsystem for Linux][wsl] lets developers run a GNU/Linux environme
 
 ```bash
 # Required Packages
-
-# On Debian-based distros
 sudo apt-get update
 sudo apt-get install build-essential qemu-system-i386 gdb libfl-dev
-
-# On Arch-based distros
-sudo pacman -Syu
-sudo pacman -S base-devel qemu-full gdb flex wget
 
 # Create directory
 sudo mkdir /opt/cross

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@
 
 <!-- /TOC -->
 
-### Notes about this fork:
-
-- QEMU doesn't support scrolling by default and several solutions found on the internet doesn't seem to work with this project for some reason.
-- Another issue when building an error with qemu was always present it was solved in this [issue](https://github.com/yousinix/fos-v2/issues/12#issuecomment-2391239145) thanks to [josefnagy1999](https://github.com/josefnagy1999)
-- I tried to check wether the QEMU problem was present in Windows too, but I had some problems with getting FOS to work on VSCode in Windows, I will try to look into it but in the meantime it's open to contribution. 
-- Steps to install and run on Arch based distros were added.
-
 ## 1. What's Different?
 
 1. **No Eclipse!** — Can be used with any text editor, _defaults to Visual Studio Code_.
@@ -106,7 +99,7 @@ sudo apt-get install build-essential qemu-system-i386 gdb libfl-dev
 
 # On Arch-based distros
 sudo pacman -Syu
-sudo pacman -S base-devel qemu-arch-extra gdb flex
+sudo pacman -S base-devel qemu-full gdb flex wget
 
 # Create directory
 sudo mkdir /opt/cross

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@
 
 <!-- /TOC -->
 
+### Notes about this fork:
+
+- QEMU doesn't support scrolling by default and several solutions found on the internet doesn't seem to work with this project for some reason.
+- Another issue when building an error with qemu was always present it was solved in this [issue](https://github.com/yousinix/fos-v2/issues/12#issuecomment-2391239145) thanks to [josefnagy1999](https://github.com/josefnagy1999)
+- I tried to check wether the QEMU problem was present in Windows too, but I had some problems with getting FOS to work on VSCode in Windows, I will try to look into it but in the meantime it's open to contribution. 
+- Steps to install and run on Arch based distros were added.
+
 ## 1. What's Different?
 
 1. **No Eclipse!** — Can be used with any text editor, _defaults to Visual Studio Code_.
@@ -92,8 +99,14 @@ The [Windows Subsystem for Linux][wsl] lets developers run a GNU/Linux environme
 
 ```bash
 # Required Packages
+
+# On Debian-based distros
 sudo apt-get update
 sudo apt-get install build-essential qemu-system-i386 gdb libfl-dev
+
+# On Arch-based distros
+sudo pacman -Syu
+sudo pacman -S base-devel qemu-arch-extra gdb flex
 
 # Create directory
 sudo mkdir /opt/cross
@@ -126,6 +139,7 @@ echo 'export PATH="$PATH:/opt/cross/bin"' >> ~/.bashrc
 [dl-repo]: https://github.com/YoussefRaafatNasry/fos-v2/archive/master.zip
 
 > \*Cloning is recommended to get the latest changes using `git pull`
+
 
 ## 4. Debugging
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ echo 'export PATH="$PATH:/opt/cross/bin"' >> ~/.bashrc
 
 > \*Cloning is recommended to get the latest changes using `git pull`
 
-
 ## 4. Debugging
 
 1. Add breakpoints to your code.


### PR DESCRIPTION
QEMU doesn't support scrolling in the emulator window by default, and all solutions found online aren't compatiable with structure of FOS, the workaround was in the GNUMakefile, instead of having the QEMU run command like this

```bash
qemu: all
	$(V)$(QEMU) -serial mon:stdio $(QEMUOPTS)
```
which only opens QEMU window after building, the command should be like this

```bash
qemu: all
	$(V)$(QEMU) -parallel mon:stdio $(QEMUOPTS)
```

This redirects the parallel port to the terminal that ran the command, in our case the VSCode terminal, where we can zoom in and out and scroll for better readability.

This was tested only on Linux and both methods for Windows.

Fixes #13 

Screenshot showing the changes:

![image](https://github.com/user-attachments/assets/3a033c21-43c6-4db3-b70f-5398ff05d590)
